### PR TITLE
Add base64enc and base64dec

### DIFF
--- a/js/src/system.js
+++ b/js/src/system.js
@@ -1,6 +1,33 @@
 var builtInCommands = {};
 
 
+/** 
+ * Base64 encodes a string.
+*/
+builtInCommands.base64enc = {
+    about: "base64enc [string]<br>&nbsp;&nbsp;Base64 encode a string.",
+    exe: function (args) {
+        if(args.length == 1){
+            return "No string specified.";
+        }
+        args.shift();
+        return btoa(args.join(" "));
+    }
+}
+
+/** 
+ * Base64 decodes a string.
+*/
+builtInCommands.base64dec = {
+    about: "base64dec [string]<br>&nbsp;&nbsp;Base64 decode a string.",
+    exe: function (args) {
+        if(args.length == 1){
+            return "No string specified.";
+        }
+        args.shift();
+        return atob(args.join(" "));
+    }
+}
 
 builtInCommands.cat = {
     about: "cat [file]<br>&nbsp;&nbsp;Display the contents of the specified file.",


### PR DESCRIPTION
Added 2 new commands, `base64enc [string]` and `base64dec [string]`.
Didn't minify the files but can do it if you provide the config for the tool you use for it.

Looking forward to making more, seems like a fun project.