### PR TITLE
Show bootloader on reboot

### DIFF
--- a/js/src/system.js
+++ b/js/src/system.js
@@ -160,10 +160,10 @@ builtInCommands.pwd = {
  **/
 builtInCommands.reboot = {
     about: "reboot<br>&nbsp;&nbsp;Reboot the terminal and reset saved environment.",
-    exe: function () {
+    exe: async function () {
         localStorage.removeItem("filesystem");
         localStorage.removeItem("history");
-        term.initSession();
+        await term.initSession();
         term.bootTerminalStart(document.getElementById("terminal"));
         return "";
     }


### PR DESCRIPTION
Fixes issue #10 by using async/await syntax.
The bootloader now appears when using the reboot command.